### PR TITLE
#1125Add button to add missing labels to an ontology.

### DIFF
--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptListPanel.html
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptListPanel.html
@@ -35,6 +35,7 @@
     </div>
     <div class="panel-footer text-right">
       <button wicket:id="add" type="submit" class="btn btn-primary"><i class="fa fa-plus" aria-hidden="true"></i> <wicket:container wicket:id="label"></wicket:container></button>
+        <button wicket:id="autoCreateLabel" type="submit" class="btn btn-primary">autoCreateLabel</button>
     </div>
   </div>
 </wicket:panel>

--- a/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptTreePanel.java
+++ b/inception-ui-kb/src/main/java/de/tudarmstadt/ukp/inception/ui/kb/ConceptTreePanel.java
@@ -127,13 +127,32 @@ public class ConceptTreePanel extends Panel {
         addLink.add(new Label("label", new ResourceModel("concept.list.add")));
         addLink.add(new WriteProtectionBehavior(kbModel));
         add(addLink);
+        add(new LambdaAjaxLink("autoCreateLabel", this::autoCreateLabel));
 
         Form<Preferences> form = new Form<>("form", CompoundPropertyModel.of(preferences));
         form.add(new CheckBox("showAllConcepts").add(
                 new LambdaAjaxFormSubmittingBehavior("change", this::actionPreferenceChanged)));
         add(form);
     }
-    
+
+    /**
+     * add button to add missing labels to an ontology
+     */
+    protected void autoCreateLabel(AjaxRequestTarget aTarget) throws Exception {
+        List<KBHandle> list = kbService.listAllConcepts(kbModel.getObject(), true);
+        //go through each resource in the KB
+        for(KBHandle kbh : list) {
+            String label = kbh.getUiLabel();
+            //get human-readable label
+            if(label.equals(kbh.getIdentifier())) {
+                Label la = new Label(label);
+                aTarget.add(la);
+            }
+        }
+
+    }
+
+
     private void actionSelectionChanged(AjaxRequestTarget aTarget) {
         // if the selection changes, publish an event denoting the change
         AjaxConceptSelectionEvent e = new AjaxConceptSelectionEvent(aTarget,


### PR DESCRIPTION
Firstly,we need to add a new button in ConceptTreePanel.html to auto-generate labels. Secondly, we need to define a new method to deal the click event of this button. When the button is clicked, the method autoCreateLabel(AjaxRequestTarget aTarget) will be invocked. In this method, we firstly go through each resource in the specific KnowledgeBase.We get an object of the KnowledgeBaseService class through the automatic injection of the Spring framework.All resources belonging to the current knowledge base are obtained by calling the object's listAllConcepts method (using a specific knowledge base as a parameter).Next, we need to iterate through all the resources we get. For each resource object, determine whether the current resource contains a tag by calling the getUiLabel() method and the getIdentifier() method. If the current resource does not contain a label, create a label attribute for it.
**What's in the PR**
* ...

**How to test manually**
* ...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
inception-ui-kb/src/main/java de.tudarmstadt.ukp.inception.ui.kb.ConceptTreePanel.html
inception-ui-kb/src/main/java de.tudarmstadt.ukp.inception.ui.kb.ConceptTreePanel.java
